### PR TITLE
Refactor/use: 페이지이동, 스켈레톤 적용 및 사용성 개선

### DIFF
--- a/src/api/getTourInfo.ts
+++ b/src/api/getTourInfo.ts
@@ -7,13 +7,15 @@ export const getTourInfo = async ({
   service,
   areaCode,
   contentTypeId,
-}: AreaBasedParams) => {
+  pageNo,
+}: AreaBasedParams & { pageNo?: number }) => {
   const res = await axios.get(
     getURL({
       endpoint,
       service,
       areaCode,
       contentTypeId,
+      pageNo,
     })
   );
   return res.data;
@@ -23,7 +25,8 @@ export const getCourseTourInfo = async ({
   service,
   areaCode,
   cat2,
-}: AreaBasedCourseParams) => {
+  pageNo,
+}: AreaBasedCourseParams & { pageNo: number }) => {
   const res = await axios.get(
     getURL({
       endpoint: "/KorService1",
@@ -32,6 +35,7 @@ export const getCourseTourInfo = async ({
       contentTypeId: 25,
       cat1: "C01",
       cat2,
+      pageNo,
     })
   );
   return res.data;

--- a/src/components/atoms/buttons/iconBtn/IconBtn.tsx
+++ b/src/components/atoms/buttons/iconBtn/IconBtn.tsx
@@ -4,10 +4,11 @@ import StyledIconBtn from "./styledIconBtn";
 interface IconBtnProps {
   Icon: IconType;
   onClick?: () => void;
+  disabled?: boolean;
 }
-const IconBtn = ({ Icon, onClick }: IconBtnProps) => {
+const IconBtn = ({ Icon, onClick, disabled }: IconBtnProps) => {
   return (
-    <StyledIconBtn onClick={onClick}>
+    <StyledIconBtn onClick={onClick} disabled={disabled}>
       <Icon />
     </StyledIconBtn>
   );

--- a/src/components/atoms/buttons/iconBtn/styledIconBtn.ts
+++ b/src/components/atoms/buttons/iconBtn/styledIconBtn.ts
@@ -8,6 +8,16 @@ const StyledIconBtn = styled.button`
   border-radius: 50%;
   background-color: ${colors.background};
   color: ${({ color }) => color || colors.yellow};
+  transition: 0.5s;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  &:hover {
+    box-shadow: rgba(149, 157, 165, 0.2) 0px 8px 24px;
+  }
 `;
 
 export default StyledIconBtn;

--- a/src/components/atoms/skeleton/Skeleton.tsx
+++ b/src/components/atoms/skeleton/Skeleton.tsx
@@ -1,0 +1,37 @@
+import { StyledCard } from "@/components/molecules/card/styledCard";
+import Image from "next/image";
+import { Margin8 } from "../styles";
+import { SkeletonStyle } from "./styled";
+
+const Skeleton = () => {
+  return (
+    <SkeletonStyle>
+      <StyledCard>
+        <Image
+          src="data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=="
+          alt="loading"
+          width={200}
+          height={200}
+          style={{ borderRadius: "0.5rem 0.5rem 0 0" }}
+        />
+        <Margin8>
+          <Image
+            width={100}
+            height={20}
+            src="data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=="
+            alt="loading"
+          />
+          <Image
+            width={180}
+            height={30}
+            src="data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=="
+            alt="loading"
+            style={{ marginBottom: "0.5rem" }}
+          />
+        </Margin8>
+      </StyledCard>
+    </SkeletonStyle>
+  );
+};
+
+export default Skeleton;

--- a/src/components/atoms/skeleton/styled.ts
+++ b/src/components/atoms/skeleton/styled.ts
@@ -1,0 +1,16 @@
+import { styled } from "styled-components";
+
+export const SkeletonStyle = styled.div`
+  @keyframes skeletonAni {
+    0% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.4;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+  animation: skeletonAni 1.5s ease-in-out 0.5s infinite;
+`;

--- a/src/components/atoms/styles.ts
+++ b/src/components/atoms/styles.ts
@@ -24,3 +24,7 @@ export const CenterBox = styled.div`
 export const Margin8 = styled.div`
   margin: 8px;
 `;
+
+export const RelativeBox = styled.div`
+  position: relative;
+`;

--- a/src/components/molecules/button/GeolocationBtn.tsx
+++ b/src/components/molecules/button/GeolocationBtn.tsx
@@ -1,8 +1,19 @@
 import { BiCurrentLocation } from "react-icons/bi";
 import IconBtn from "../../atoms/buttons/iconBtn/IconBtn";
+import { IconContext } from "react-icons";
 
-const GeolocationBtn = ({ onClick }: { onClick: () => void }) => {
-  return <IconBtn Icon={BiCurrentLocation} onClick={onClick} />;
+const GeolocationBtn = ({
+  onClick,
+  iconSize,
+}: {
+  onClick: () => void;
+  iconSize: string;
+}) => {
+  return (
+    <IconContext.Provider value={{ size: iconSize }}>
+      <IconBtn Icon={BiCurrentLocation} onClick={onClick} />
+    </IconContext.Provider>
+  );
 };
 
 export default GeolocationBtn;

--- a/src/components/molecules/button/PageBtns.tsx
+++ b/src/components/molecules/button/PageBtns.tsx
@@ -1,0 +1,36 @@
+import IconBtn from "@/components/atoms/buttons/iconBtn/IconBtn";
+import { IconContext } from "react-icons";
+import { GrFormNextLink, GrFormPreviousLink } from "react-icons/gr";
+import { BtnLayout } from "./styled";
+import { colors } from "@/styles/colors";
+
+const PageBtns = ({
+  handlePrev,
+  handleNext,
+  pageNo,
+  lastPage,
+}: {
+  handlePrev: () => void;
+  handleNext: () => void;
+  pageNo?: number;
+  lastPage?: number;
+}) => {
+  return (
+    <BtnLayout>
+      <IconContext.Provider value={{ size: "2rem" }}>
+        <IconBtn
+          Icon={GrFormPreviousLink}
+          onClick={handlePrev}
+          disabled={pageNo === 1}
+        />
+        <IconBtn
+          Icon={GrFormNextLink}
+          onClick={handleNext}
+          disabled={pageNo === lastPage}
+        />
+      </IconContext.Provider>
+    </BtnLayout>
+  );
+};
+
+export default PageBtns;

--- a/src/components/molecules/button/styled.ts
+++ b/src/components/molecules/button/styled.ts
@@ -1,0 +1,12 @@
+import { styled } from "styled-components";
+
+export const BtnLayout = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  position: absolute;
+  padding: 1rem;
+  top: 50%;
+  left: 0;
+  z-index: 1;
+`;

--- a/src/components/molecules/card/styledCard.ts
+++ b/src/components/molecules/card/styledCard.ts
@@ -1,10 +1,8 @@
-import { colors } from "@/styles/colors";
 import { styled } from "styled-components";
 
 export const StyledCard = styled.div`
   width: 200px;
   border-radius: 0.5rem;
-  /* margin: 0.5rem; */
   background-color: #ffffff;
 `;
 
@@ -13,6 +11,7 @@ export const CardWrapper = styled.div`
   flex-wrap: wrap;
   justify-content: center;
   padding-bottom: 2rem;
+  position: relative;
 `;
 
 export const CardGrid = styled.div`

--- a/src/components/molecules/tab/TabBody.tsx
+++ b/src/components/molecules/tab/TabBody.tsx
@@ -3,6 +3,8 @@ import CardController from "@/components/organisms/card/CardController";
 import { CardGrid, CardWrapper } from "../card/styledCard";
 import { TabType } from "@/types/type";
 import { InitTab } from "@/hooks/useTab";
+import Char from "@/components/atoms/texts/Character";
+import { CenterBox } from "@/components/atoms/styles";
 
 const TabBody = ({
   curTab,
@@ -23,9 +25,17 @@ const TabBody = ({
               key={code}
             >
               <CardWrapper>
-                <CardGrid>
-                  <CardController cardData={cardData} />
-                </CardGrid>
+                {cardData.length > 0 ? (
+                  <CardGrid>
+                    <CardController cardData={cardData} />
+                  </CardGrid>
+                ) : (
+                  <CenterBox>
+                    <Char size="md" weight="thin">
+                      관련 데이터가 없습니다.
+                    </Char>
+                  </CenterBox>
+                )}
               </CardWrapper>
             </StyledTabBox>
           );

--- a/src/components/molecules/tab/styles.ts
+++ b/src/components/molecules/tab/styles.ts
@@ -32,6 +32,6 @@ export const StyledTabBody = styled.div`
   }
 `;
 
-export const StyledTabBox = styled.section<{ $active: boolean }>`
+export const StyledTabBox = styled.section<{ $active?: boolean }>`
   display: ${({ $active }) => ($active ? "block" : "none")};
 `;

--- a/src/components/organisms/card/CardList.tsx
+++ b/src/components/organisms/card/CardList.tsx
@@ -6,6 +6,12 @@ import { getValueFromArr } from "@/utills/getValWithId";
 import { Area } from "@/types/area";
 import { Endpoint } from "@/types/endPoint";
 import { CardGrid } from "@/components/molecules/card/styledCard";
+import PageBtns from "@/components/molecules/button/PageBtns";
+import usePageBtn from "@/hooks/usePageBtn";
+import { getData } from "@/utills/getData";
+import { getLastPage } from "@/utills/getLastPage";
+import Skeleton from "@/components/atoms/skeleton/Skeleton";
+import { loadComponentNtime } from "@/utills/loadComponentNtime";
 
 interface CardListProps {
   selection: Selected[];
@@ -14,17 +20,30 @@ const CardList = ({ selection }: CardListProps) => {
   const endpoint = getValueFromArr(selection, "who") as Endpoint["endpoint"];
   const contentTypeId = getValueFromArr(selection, "what") as ContentType["id"];
   const areaCode = getValueFromArr(selection, "where") as Area["code"];
+  const { pageNo, handlePrev, handleNext } = usePageBtn();
 
   const { data, isLoading } = useAreaBasedTourInfo({
     endpoint,
     areaCode,
     contentTypeId,
+    pageNo: pageNo || 1,
   });
-  const cardData = data?.response?.body?.items?.item || [];
+  const cardData = getData(data);
+  const lastPage = getLastPage(cardData.totalItemNo);
 
   return (
     <CardGrid>
-      <CardController cardData={cardData} />
+      <PageBtns
+        pageNo={pageNo}
+        lastPage={lastPage}
+        handlePrev={handlePrev}
+        handleNext={handleNext}
+      />
+      {isLoading ? (
+        loadComponentNtime(<Skeleton />, 10)
+      ) : (
+        <CardController cardData={cardData.itemList} />
+      )}
     </CardGrid>
   );
 };

--- a/src/components/organisms/card/SkeletonList.tsx
+++ b/src/components/organisms/card/SkeletonList.tsx
@@ -1,0 +1,13 @@
+import Skeleton from "@/components/atoms/skeleton/Skeleton";
+import { CardGrid } from "@/components/molecules/card/styledCard";
+import { loadComponentNtime } from "@/utills/loadComponentNtime";
+
+const SkeletonList = () => {
+  return (
+    <>
+      <CardGrid>{loadComponentNtime(<Skeleton />, 10)}</CardGrid>
+    </>
+  );
+};
+
+export default SkeletonList;

--- a/src/components/organisms/card/styled.ts
+++ b/src/components/organisms/card/styled.ts
@@ -1,3 +1,4 @@
+import { colors } from "@/styles/colors";
 import { styled } from "styled-components";
 
 export const StyledCardList = styled.section`
@@ -9,11 +10,29 @@ export const StyledCardList = styled.section`
 
 export const OverFlowHidden = styled.section`
   width: 100%;
-  overflow-x: scroll;
+  overflow: hidden;
+  /* overflow-x: scroll; */
 `;
 
 export const HorizontalCardList = styled.div`
-  display: flex;
-  flex-wrap: nowrap;
-  flex-direction: row;
+  display: grid;
+  grid-gap: 1rem;
+  grid-template-columns: repeat(10, 1fr);
+`;
+
+export const HorizontalWrapper = styled.div`
+  overflow-x: auto;
+  width: 100%;
+  padding: 1rem;
+  margin-bottom: 5rem;
+  background-color: ${colors.green};
+  scroll-padding: 0 1rem;
+  //스크롤바: width를 줘야 스타일이 먹는다.
+  &::-webkit-scrollbar {
+    width: 0.5rem;
+  }
+  &::-webkit-scrollbar-thumb {
+    border-radius: 0.5rem;
+    background: ${colors.green};
+  }
 `;

--- a/src/components/organisms/tab/Tab.tsx
+++ b/src/components/organisms/tab/Tab.tsx
@@ -3,11 +3,14 @@ import TabHead from "@/components/molecules/tab/TabHead";
 import { StyledTab } from "./styles";
 import { TabType } from "@/types/type";
 import { InitTab } from "@/hooks/useTab";
+import SkeletonList from "../card/SkeletonList";
+import { CardWrapper } from "@/components/molecules/card/styledCard";
 
 const Tab = ({
   tabList,
   tabState,
   cardData,
+  isLoading,
 }: {
   tabList: TabType[];
   tabState: {
@@ -15,13 +18,20 @@ const Tab = ({
     curTab: InitTab;
   };
   cardData: any;
+  isLoading: boolean;
 }) => {
   const { setCurTab, curTab } = tabState;
 
   return (
     <StyledTab>
       <TabHead tabList={tabList} setCurTab={setCurTab} curTab={curTab} />
-      <TabBody tabCategory={tabList} curTab={curTab} cardData={cardData} />
+      {isLoading ? (
+        <CardWrapper>
+          <SkeletonList />
+        </CardWrapper>
+      ) : (
+        <TabBody tabCategory={tabList} curTab={curTab} cardData={cardData} />
+      )}
     </StyledTab>
   );
 };

--- a/src/components/organisms/tab/styles.ts
+++ b/src/components/organisms/tab/styles.ts
@@ -1,7 +1,7 @@
-import { colors } from "@/styles/colors";
 import { styled } from "styled-components";
 
 export const StyledTab = styled.section`
   position: relative;
   overflow: hidden;
+  margin-top: 3rem;
 `;

--- a/src/components/templetes/CourseSection.tsx
+++ b/src/components/templetes/CourseSection.tsx
@@ -12,13 +12,18 @@ import { categoryState } from "@/recoil/atoms/categoryState";
 import { useEffect } from "react";
 import { useThemeCourseTour } from "@/hooks/useTourInfo";
 import { Cat2 } from "@/types/course";
-import { recoilTabState } from "@/recoil/atoms/tabState";
+import PageBtns from "../molecules/button/PageBtns";
+import { RelativeBox } from "../atoms/styles";
+import usePageBtn from "@/hooks/usePageBtn";
+import { getData } from "@/utills/getData";
+import { getLastPage } from "@/utills/getLastPage";
 
 const CourseSection = () => {
   const [selection] = useRecoilState<Selected[]>(selectOptionSelector);
   const [category, setCategory] = useRecoilState(categoryState);
   const areaCode = getValueFromArr(selection, "where") as Area["code"];
-  const { data: categories } = useCategory();
+  const { data: categories, isLoading: isCategoryLoading } = useCategory();
+  const { pageNo, handlePrev, handleNext } = usePageBtn();
 
   useEffect(() => {
     categories && setCategory(categories?.response?.body?.items?.item);
@@ -29,17 +34,31 @@ const CourseSection = () => {
     icons: icons,
   });
 
-  // @todo 데이터 리코일로 관리하기
   const { data, isLoading } = useThemeCourseTour({
     areaCode: areaCode || 1,
     cat2: (tabState.curTab.code as Cat2["code"]) || "C0112",
+    pageNo: pageNo || 1,
   });
-  const cardData = data?.response?.body?.items?.item || [];
+  const cardData = getData(data);
+  const lastPage = getLastPage(cardData.totalItemNo);
 
   return (
-    <>
-      <Tab tabList={tabList} tabState={tabState} cardData={cardData} />
-    </>
+    <RelativeBox>
+      <>
+        <PageBtns
+          pageNo={pageNo}
+          lastPage={lastPage}
+          handlePrev={handlePrev}
+          handleNext={handleNext}
+        />
+        <Tab
+          isLoading={isLoading}
+          tabList={tabList}
+          tabState={tabState}
+          cardData={cardData.itemList}
+        />
+      </>
+    </RelativeBox>
   );
 };
 

--- a/src/components/templetes/CustomSection.tsx
+++ b/src/components/templetes/CustomSection.tsx
@@ -6,14 +6,27 @@ import { Selected } from "@/recoil/atoms/selectState";
 import CardList from "../organisms/card/CardList";
 import { CardWrapper } from "../molecules/card/styledCard";
 import { selectOptionSelector } from "@/recoil/selectors/selectOptionSelector";
+import Title from "../molecules/title/Title";
+import { CenterBox } from "../atoms/styles";
 
 const CustomSection = ({ isSelect }: { isSelect: boolean }) => {
   const [selection] = useRecoilState<Selected[]>(selectOptionSelector);
 
   return (
-    <CardWrapper>
-      <CardList selection={isSelect ? selection : []} />
-    </CardWrapper>
+    <>
+      <CenterBox>
+        {isSelect ? (
+          selection?.map((tag, i) => (
+            <Title key={i} type="main" text={`#${tag.value}`} />
+          ))
+        ) : (
+          <Title type="main" text="내 여행 테마는?" />
+        )}
+      </CenterBox>
+      <CardWrapper>
+        <CardList selection={isSelect ? selection : []} />
+      </CardWrapper>
+    </>
   );
 };
 

--- a/src/components/templetes/LocationSection.tsx
+++ b/src/components/templetes/LocationSection.tsx
@@ -3,16 +3,24 @@
 import React from "react";
 import Char from "../atoms/texts/Character";
 import CardController from "../organisms/card/CardController";
-import { HorizontalCardList, OverFlowHidden } from "../organisms/card/styled";
+import {
+  HorizontalCardList,
+  HorizontalWrapper,
+  OverFlowHidden,
+} from "../organisms/card/styled";
 import GeolocationBtn from "../molecules/button/GeolocationBtn";
 import useCurTour from "@/hooks/useCurTour";
 import getConfirm from "@/utills/getConfirm";
 import { useRecoilState } from "recoil";
 import { Area } from "@/types/area";
 import { areaSelector } from "@/recoil/selectors/areaSelector";
+import Title from "../molecules/title/Title";
+import { CenterBox } from "../atoms/styles";
+import Skeleton from "../atoms/skeleton/Skeleton";
+import { loadComponentNtime } from "@/utills/loadComponentNtime";
 
 const LocationSection = () => {
-  const { courseData, curAreaCode, refethPosition } = useCurTour();
+  const { courseData, curAreaCode, refethPosition, isLoading } = useCurTour();
   const [areas] = useRecoilState<Area[]>(areaSelector);
 
   const curAreaName = areas?.find((el: { code: Area["code"] }) => {
@@ -28,18 +36,30 @@ const LocationSection = () => {
 
   return (
     <OverFlowHidden>
-      <Char size="md" weight="bold">
-        {curAreaName}에서 하는 여행코스
-        <GeolocationBtn onClick={clickLocationBtn} />
-      </Char>
-      <HorizontalCardList>
-        <CardController cardData={courseData} />
-        {courseData.length === 0 && (
-          <Char size="sm" weight="mid">
-            현재 해당 위치의 여행코스 데이터가 없습니다.
-          </Char>
-        )}
-      </HorizontalCardList>
+      <CenterBox>
+        <div>
+          <Title type="main" text="내 주변 여행지" />
+          <div>
+            <Char size="md" weight="bold">
+              {`#${curAreaName}`}에서 하는 여행코스
+            </Char>
+          </div>
+        </div>
+        <GeolocationBtn onClick={clickLocationBtn} iconSize="2rem" />
+      </CenterBox>
+      <HorizontalWrapper>
+        <HorizontalCardList>
+          {isLoading ? (
+            loadComponentNtime(<Skeleton />, 10)
+          ) : courseData.length === 0 ? (
+            <Char size="sm" weight="mid">
+              현재 해당 위치의 여행코스 데이터가 없습니다.
+            </Char>
+          ) : (
+            <CardController cardData={courseData} />
+          )}
+        </HorizontalCardList>
+      </HorizontalWrapper>
     </OverFlowHidden>
   );
 };

--- a/src/hooks/useCurTour.ts
+++ b/src/hooks/useCurTour.ts
@@ -23,7 +23,7 @@ const useCurTour = () => {
   const courseData = data?.response?.body?.items?.item || [];
   const curAreaCode = courseData[0]?.areacode;
 
-  return { courseData, curAreaCode, refethPosition };
+  return { courseData, curAreaCode, refethPosition, isLoading };
 };
 
 export default useCurTour;

--- a/src/hooks/usePageBtn.ts
+++ b/src/hooks/usePageBtn.ts
@@ -1,0 +1,16 @@
+import { useState } from "react";
+
+const usePageBtn = () => {
+  const [pageNo, setPageNo] = useState(1);
+  const handlePrev = () => {
+    setPageNo(pageNo - 1);
+  };
+
+  const handleNext = () => {
+    setPageNo(pageNo + 1);
+  };
+
+  return { pageNo, handlePrev, handleNext };
+};
+
+export default usePageBtn;

--- a/src/hooks/useTourInfo.ts
+++ b/src/hooks/useTourInfo.ts
@@ -20,15 +20,17 @@ export const useAreaBasedTourInfo = ({
   endpoint,
   areaCode,
   contentTypeId,
-}: Partial<AreaBasedParams>) => {
+  pageNo = 1,
+}: Partial<AreaBasedParams> & { pageNo?: number }) => {
   const params = {
     service: "/areaBasedList1",
     areaCode,
     contentTypeId,
     endpoint,
+    pageNo,
   };
   return useQuery({
-    queryKey: ["/areaBasedList1", { areaCode, contentTypeId }],
+    queryKey: ["/areaBasedList1", { areaCode, contentTypeId, pageNo }],
     queryFn: () => getTourInfo(params),
   });
 };
@@ -37,14 +39,16 @@ export const useThemeCourseTour = ({
   service,
   areaCode = "1",
   cat2 = "C0112",
-}: Partial<AreaBasedCourseParams>) => {
+  pageNo = 1,
+}: Partial<AreaBasedCourseParams> & { pageNo?: number }) => {
   const params = {
     service: "/areaBasedList1",
     areaCode,
     cat2,
+    pageNo,
   };
   return useQuery({
-    queryKey: ["/areaBasedList1", cat2],
+    queryKey: ["/areaBasedList1", { cat2, pageNo }],
     queryFn: () => getCourseTourInfo(params),
   });
 };

--- a/src/hooks/useTourInfo.ts
+++ b/src/hooks/useTourInfo.ts
@@ -28,7 +28,7 @@ export const useAreaBasedTourInfo = ({
     endpoint,
   };
   return useQuery({
-    queryKey: ["/areaBasedList1"],
+    queryKey: ["/areaBasedList1", { areaCode, contentTypeId }],
     queryFn: () => getTourInfo(params),
   });
 };

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -4,6 +4,23 @@ import { IconType } from "react-icons";
 export type RESPONSE_OK = "OK";
 export type RESPONSE_ERROR = "ERROR";
 
+export interface DataStructure {
+  response: {
+    header: {
+      resultCode: string;
+      resultMsg: RESPONSE_OK | RESPONSE_ERROR | string;
+    };
+    body: {
+      items: {
+        item: [];
+      };
+      numOfRows: number;
+      pageNo: number;
+      totalCount: number;
+    };
+  };
+}
+
 export interface TagType {
   id?: number | string;
   code?: string | number;

--- a/src/utills/getData.ts
+++ b/src/utills/getData.ts
@@ -1,0 +1,8 @@
+import { DataStructure } from "@/types/type";
+
+export const getData = (data: DataStructure) => {
+  const itemList = data?.response?.body?.items?.item || [];
+  const totalItemNo = data?.response?.body?.totalCount || 1;
+
+  return { itemList, totalItemNo };
+};

--- a/src/utills/getLastPage.ts
+++ b/src/utills/getLastPage.ts
@@ -1,0 +1,4 @@
+export const getLastPage = (totalCount: number, numOfRows: number = 10) => {
+  if (totalCount < numOfRows) return 1;
+  return Math.ceil(totalCount / numOfRows);
+};

--- a/src/utills/loadComponentNtime.ts
+++ b/src/utills/loadComponentNtime.ts
@@ -1,0 +1,10 @@
+import React from "react";
+
+export const loadComponentNtime = (component: React.ReactNode, n: number) => {
+  const components = [];
+
+  for (let i = 0; i < n; i++) {
+    components.push(component);
+  }
+  return components;
+};


### PR DESCRIPTION
#12 
## pageBtns
```jsx
const CardList = ({ selection }: CardListProps) => {
  const { pageNo, handlePrev, handleNext } = usePageBtn();

  const { data, isLoading } = useAreaBasedTourInfo({
    endpoint,
    areaCode,
    contentTypeId,
    pageNo: pageNo || 1,
  });
  const cardData = getData(data);
  const lastPage = getLastPage(cardData.totalItemNo);

  return (
    <CardGrid>
      <PageBtns
        pageNo={pageNo}
        lastPage={lastPage}
        handlePrev={handlePrev}
        handleNext={handleNext}
      />
      <CardController cardData={cardData.itemList} />
    </CardGrid>
  );
};

export default CardList;
```
### usePageBtn
1. pageNo: 현재 페이지
2. handlePrev: 이전 페이지로 이동시킨다.
3. handleNext: 다음페이지로 이동시킨다.

### PageBtns
페이지 버튼을 사용할 컴포넌트에 적절히 위치시킨다.
usePageBtn 훅으로 생성되는 구성요소들을 모두 전달한다.
disabled를 활성화시키고 싶으면 lastPage 정보 또한 전달해야한다.

### 유틸함수: getData, getLastPage
getData에 리액트쿼리로 받은 데이터를 넘기면 적절한 형태로 데이터를 가공한다.
itemList와 totalItemNo(전체 데이터 아이템 갯수)를 객체 형태로 리턴함.
totalItemNo는 getLastPage 함수의 파라미터로 활용한다. 전체 페이지 수를 계산해준다.

## skeleton
사용성 개선을 위해 skeleton UI를 만들어 적용함.
base64, Image 함께 사용.
useQuery에서 제공하는 isLoading과 결합해서 간단히 구현.
### 사용법: loadComponentNtime 유틸함수 사용
```jsx
{isLoading && loadComponentNtime(<Skeleton />, 10)}
```
반복생성할 컴포넌트(리액트노드), 반복할 갯수를 함께 전달해 렌더링한다.

## 그외
* 위치기반 서비스 섹션 레이아웃 및 디자인 수정
* select button 작동 에러 해결
  useQuery 사용시 query key 적절하게 추가해서 트리거를 의도했다.
  이 경우에는 selection들이 수정되었을때 발생해야하는데, areaCode와 contentTypeId를 추가해서 문제를 해결할 수있었음.