### PR TITLE
fix: page btn error fix and implement recoil on tab section

### DIFF
--- a/src/components/atoms/tab/tabItem.tsx
+++ b/src/components/atoms/tab/tabItem.tsx
@@ -3,7 +3,7 @@ import { IconContext } from "react-icons";
 import { TabType } from "@/types/type";
 
 type TabItemProps = {
-  Icon: TabType["icon"];
+  Icon?: TabType["icon"];
   label: TabType["name"];
   onClick: () => void;
   isActive: boolean;

--- a/src/components/molecules/card/CardTab.tsx
+++ b/src/components/molecules/card/CardTab.tsx
@@ -1,21 +1,20 @@
 import Char from "@/components/atoms/texts/Character";
 import { DetailData } from "./DetailCard";
-import useTab from "@/hooks/useTab";
 import { TabType } from "@/types/type";
-import TabHead from "../tab/TabHead";
 import {
   StyledCardTab,
   StyledCardTabBody,
   StyledCourseCard,
 } from "./styledCard";
-import { StyledTabBox } from "../tab/styles";
+import { StyledTabBox, StyledTabHead } from "../tab/styles";
 import { CourseTour } from "@/types/course";
 import Table from "../table/Table";
 import CourseCard from "./CourseCard";
 import PetCard from "./PetCard";
 import { PetTour } from "@/types/tourPet";
 import Nodata from "../noData/Nodata";
-import { CustomScrollbar } from "@/components/atoms/styles";
+import useCardTab, { InitTab } from "@/hooks/useCardTab";
+import TabItem from "@/components/atoms/tab/tabItem";
 
 const CardTab = ({
   detailInfo,
@@ -32,14 +31,29 @@ const CardTab = ({
   petInfo: PetTour;
   barrierFree: any;
 }) => {
-  const { tabState, tabList } = useTab({
+  const { tabState, tabList } = useCardTab({
     category: cardTabList,
   });
   const { curTab, setCurTab } = tabState;
 
+  const handleTab = ({ name, code, idx }: InitTab) => {
+    setCurTab({ name, code, idx });
+  };
+
   return (
     <StyledCardTab>
-      <TabHead tabList={cardTabList} setCurTab={setCurTab} curTab={curTab} />
+      <StyledTabHead>
+        {tabList?.map(({ code, name }, i) => {
+          return (
+            <TabItem
+              key={"cardTab" + code}
+              label={name}
+              isActive={curTab.code ? curTab.code === code : i === 0}
+              onClick={() => handleTab({ name, code, idx: i })}
+            />
+          );
+        })}
+      </StyledTabHead>
       <StyledCardTabBody>
         <StyledTabBox $active={curTab.idx === 0}>
           <StyledCourseCard>

--- a/src/components/molecules/tab/TabBody.tsx
+++ b/src/components/molecules/tab/TabBody.tsx
@@ -2,27 +2,29 @@ import { StyledTabBody, StyledTabBox } from "./styles";
 import CardController from "@/components/organisms/card/CardController";
 import { CardGrid, CardWrapper } from "../card/styledCard";
 import { TabType } from "@/types/type";
-import { InitTab } from "@/hooks/useTab";
 import { CenterBox } from "@/components/atoms/styles";
 import Nodata from "../noData/Nodata";
+import { InitAllTab } from "@/recoil/atoms/tabState";
 
 const TabBody = ({
-  curTab,
+  allTab,
   tabCategory,
   cardData,
 }: {
-  curTab: InitTab;
+  allTab: InitAllTab[];
   tabCategory: TabType[];
   cardData: any;
 }) => {
+  const currentTabCode = allTab.find((tab) => tab.isCurTab)?.code || "";
+
   return (
     <>
       <StyledTabBody>
-        {tabCategory?.map(({ code, name, label }, i) => {
+        {tabCategory?.map(({ code }, i) => {
           return (
             <StyledTabBox
-              $active={curTab.code ? curTab.code === code : i === 0}
-              key={"category" + code}
+              $active={currentTabCode ? currentTabCode === code : i === 0}
+              key={"categoryBody" + code}
             >
               <CardWrapper>
                 {cardData.length > 0 ? (

--- a/src/components/molecules/tab/TabHead.tsx
+++ b/src/components/molecules/tab/TabHead.tsx
@@ -1,31 +1,32 @@
 import TabItem from "@/components/atoms/tab/tabItem";
 import { StyledTabHead } from "./styles";
-import { TabType } from "@/types/type";
-import { InitTab } from "@/hooks/useTab";
+import { InitAllTab } from "@/recoil/atoms/tabState";
 
 const TabHead = ({
   tabList,
-  setCurTab,
-  curTab,
+  handleCurTab,
 }: {
-  tabList: TabType[];
-  setCurTab: React.Dispatch<React.SetStateAction<InitTab>>;
-  curTab: InitTab;
+  tabList: InitAllTab[];
+  handleCurTab: (tab: InitAllTab) => void;
 }) => {
-  const handleTab = ({ name, code, idx }: InitTab) => {
-    setCurTab({ name, code, idx });
-  };
-
   return (
     <StyledTabHead>
-      {tabList?.map(({ code, name, label, icon }, i) => {
+      {tabList?.map(({ code, name, icon, isCurTab, tabPage }, i) => {
         return (
           <TabItem
-            key={"catagory" + code}
+            key={"catagoryHead" + code}
             label={name}
-            isActive={curTab.code ? curTab.code === code : i === 0}
+            isActive={isCurTab}
             Icon={icon}
-            onClick={() => handleTab({ name, code, idx: i })}
+            onClick={() => {
+              handleCurTab({
+                name,
+                code,
+                idx: i,
+                tabPage,
+                isCurTab: isCurTab,
+              });
+            }}
           />
         );
       })}

--- a/src/components/organisms/tab/Tab.tsx
+++ b/src/components/organisms/tab/Tab.tsx
@@ -1,29 +1,22 @@
 import TabBody from "@/components/molecules/tab/TabBody";
 import TabHead from "@/components/molecules/tab/TabHead";
 import { StyledTab } from "./styles";
-import { TabType } from "@/types/type";
-import { InitTab } from "@/hooks/useTab";
+import { InitAllTab } from "@/recoil/atoms/tabState";
 
 const Tab = ({
   tabList,
-  tabState,
+  handleCurTab,
   cardData,
-  isLoading,
 }: {
-  tabList: TabType[];
-  tabState: {
-    setCurTab: React.Dispatch<React.SetStateAction<InitTab>>;
-    curTab: InitTab;
-  };
+  tabList: InitAllTab[];
+  handleCurTab: (tab: InitAllTab) => void;
   cardData: any;
   isLoading: boolean;
 }) => {
-  const { setCurTab, curTab } = tabState;
-
   return (
     <StyledTab>
-      <TabHead tabList={tabList} setCurTab={setCurTab} curTab={curTab} />
-      <TabBody tabCategory={tabList} curTab={curTab} cardData={cardData} />
+      <TabHead handleCurTab={handleCurTab} tabList={tabList} />
+      <TabBody tabCategory={tabList} allTab={tabList} cardData={cardData} />
     </StyledTab>
   );
 };

--- a/src/components/templetes/CourseSection.tsx
+++ b/src/components/templetes/CourseSection.tsx
@@ -29,16 +29,21 @@ const CourseSection = () => {
     categories && setCategory(categories?.response?.body?.items?.item);
   }, [categories, setCategory]);
 
-  const { tabState, tabList } = useTab({
+  const { tabList, handleCurTab, handleTabPage } = useTab({
     category,
     icons: icons,
   });
 
+  const curTab =
+    tabList.find((tab) => tab.isCurTab === true) ||
+    tabList.find((tab) => tab.idx === 0);
+
   const { data, isLoading } = useThemeCourseTour({
     areaCode: areaCode || 1,
-    cat2: (tabState.curTab.code as Cat2["code"]) || "C0112",
-    pageNo: pageNo || 1,
+    cat2: (curTab?.code as Cat2["code"]) || "C0112",
+    pageNo: curTab?.tabPage,
   });
+
   const cardData = getData(data);
   const lastPage = getLastPage(cardData.totalItemNo);
 
@@ -46,15 +51,23 @@ const CourseSection = () => {
     <RelativeBox>
       <>
         <PageBtns
-          pageNo={pageNo}
+          pageNo={curTab?.tabPage}
           lastPage={lastPage}
-          handlePrev={handlePrev}
-          handleNext={handleNext}
+          handlePrev={() => {
+            if (pageNo > 1) {
+              handlePrev();
+              handleTabPage(curTab?.code, pageNo - 1);
+            }
+          }}
+          handleNext={() => {
+            handleNext();
+            handleTabPage(curTab?.code, pageNo + 1);
+          }}
         />
         <Tab
           isLoading={isLoading}
           tabList={tabList}
-          tabState={tabState}
+          handleCurTab={handleCurTab}
           cardData={cardData.itemList}
         />
       </>

--- a/src/components/templetes/CustomSection.tsx
+++ b/src/components/templetes/CustomSection.tsx
@@ -50,8 +50,8 @@ const CustomSection = ({ isSelect }: { isSelect: boolean }) => {
       <PageBtns
         pageNo={pageNo}
         lastPage={lastPage}
-        handlePrev={() => handlePrev(pageNo)}
-        handleNext={() => handleNext(pageNo)}
+        handlePrev={handlePrev}
+        handleNext={handleNext}
       />
       <CardWrapper>
         <CardList cardData={cardData?.itemList} />

--- a/src/components/templetes/CustomSection.tsx
+++ b/src/components/templetes/CustomSection.tsx
@@ -50,8 +50,8 @@ const CustomSection = ({ isSelect }: { isSelect: boolean }) => {
       <PageBtns
         pageNo={pageNo}
         lastPage={lastPage}
-        handlePrev={handlePrev}
-        handleNext={handleNext}
+        handlePrev={() => handlePrev(pageNo)}
+        handleNext={() => handleNext(pageNo)}
       />
       <CardWrapper>
         <CardList cardData={cardData?.itemList} />

--- a/src/hooks/useCardTab.ts
+++ b/src/hooks/useCardTab.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+import { iconType } from "@/variables/icons";
+import { TabType } from "@/types/type";
+
+export type InitTab = TabType & { idx: number };
+
+const useCardTab = ({
+  category,
+}: {
+  category: TabType[];
+  icons?: iconType[];
+}) => {
+  const initialTab: InitTab = { name: "", code: "", idx: 0 };
+  const [curTab, setCurTab] = useState<InitTab>(initialTab);
+
+  return { tabState: { curTab, setCurTab }, tabList: category };
+};
+
+export default useCardTab;

--- a/src/hooks/usePageBtn.ts
+++ b/src/hooks/usePageBtn.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 const usePageBtn = () => {
   const [pageNo, setPageNo] = useState(1);
+
   const handlePrev = () => {
     setPageNo(pageNo - 1);
   };

--- a/src/hooks/useTab.ts
+++ b/src/hooks/useTab.ts
@@ -1,9 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { iconType } from "@/variables/icons";
 import { combineCategoriesWithIcons } from "@/utills/getIconMap";
 import { TabType } from "@/types/type";
-
-export type InitTab = TabType & { idx: number };
+import { InitAllTab, allTabState } from "@/recoil/atoms/tabState";
+import { useRecoilState } from "recoil";
 
 const useTab = ({
   category,
@@ -12,18 +12,50 @@ const useTab = ({
   category: TabType[];
   icons?: iconType[];
 }) => {
-  const initialTab: InitTab = { name: "", code: "", idx: 0 };
-  const [curTab, setCurTab] = useState<InitTab>(initialTab);
+  const [allTab, setAllTab] = useRecoilState(allTabState);
 
-  let tabList;
+  let tabList: any;
 
   if (icons) {
     tabList = combineCategoriesWithIcons({ category, icons });
   } else {
     tabList = category;
   }
+  useEffect(() => {
+    //tabData 세팅, curTab 0번인덱스로 설정.
+    const initAllTab = tabList?.map((tab: any, idx: number) => ({
+      isCurTab: idx === 0 ? true : false,
+      code: tab.code,
+      name: tab.name,
+      icon: tab.icon,
+      idx: idx,
+      tabPage: 1,
+    }));
+    setAllTab(initAllTab);
+  }, [tabList?.length !== 0]);
 
-  return { tabState: { curTab, setCurTab }, tabList };
+  const handleCurTab = (tab: InitAllTab) => {
+    setAllTab((prevAllTab) => {
+      return prevAllTab.map((prevTab) => ({
+        ...prevTab,
+        isCurTab: prevTab.code === tab.code,
+        tabPage: prevTab.code === tab.code ? tab.tabPage : prevTab.tabPage,
+      }));
+    });
+  };
+
+  const handleTabPage = (tabCode: string | undefined, tabPage: number) => {
+    if (!tabCode) return;
+
+    setAllTab((prevAllTab) => {
+      return prevAllTab.map((prevTab) => ({
+        ...prevTab,
+        tabPage: prevTab.code === tabCode ? tabPage : prevTab.tabPage,
+      }));
+    });
+  };
+
+  return { tabList: allTab, handleCurTab, handleTabPage };
 };
 
 export default useTab;

--- a/src/recoil/atoms/tabState.ts
+++ b/src/recoil/atoms/tabState.ts
@@ -1,12 +1,12 @@
 import { TabType } from "@/types/type";
 import { atom } from "recoil";
+export type InitAllTab = Pick<TabType, "name" | "code" | "icon"> & {
+  idx: number;
+} & {
+  tabPage: number;
+} & { isCurTab: boolean };
 
-interface TabState {
-  curTab: TabType;
-  tabData: {};
-}
-
-export const recoilTabState = atom<TabState[]>({
-  key: "tabState",
+export const allTabState = atom<InitAllTab[]>({
+  key: "allTabState",
   default: [],
 });

--- a/src/recoil/selectors/tabSelector.ts
+++ b/src/recoil/selectors/tabSelector.ts
@@ -1,8 +1,8 @@
 import { selector } from "recoil";
-import { recoilTabState } from "../atoms/tabState";
+import { allTabState } from "../atoms/tabState";
 
 export const tabSelector = selector({
-  key: "tabSelector",
-  get: ({ get }) => get(recoilTabState),
-  set: ({ set }, newValue) => set(recoilTabState, newValue),
+  key: "allTabSelector",
+  get: ({ get }) => get(allTabState),
+  set: ({ set }, newValue) => set(allTabState, newValue),
 });


### PR DESCRIPTION
#19 
## 페이지네이션 에러 수정
에러 발생 원인: tab 섹션에서 모든 탭이 page 상태를 공유해서 발생한 에러.

## 해결
recoil로 tab 상태 관리. 각 탭이 isActive, tabPage라는 값을 갖도록 수정.

### tabState type
```tsx
export type InitAllTab = Pick<TabType, "name" | "code" | "icon"> & {
  idx: number;
} & {
  tabPage: number;
} & { isCurTab: boolean };
```

### useTab
탭 훅을 대대적으로 수정함.
useEffect를 사용해 초기 렌더링시 tabList가 들어오면 tabData를 세팅하도록 함.
#### 사용
```tsx
// CourseSection.tsx 중
  const { tabList, handleCurTab, handleTabPage } = useTab({
    category,
    icons: icons,
  });
```
* category, icon을 useTab에 전달하면 tabList를 만들어준다.(icon은 선택)
* handleCurTab: tabList중 현재 탭의 isActive 값을 true로 전환한다.
* handleTabPage: 현재 탭의 tabPage를 업데이트한다.
  아래와 같이 페이지버튼과 결합해 사용함.
```tsx
        <PageBtns
          pageNo={curTab?.tabPage}
          lastPage={lastPage}
          handlePrev={() => {
            if (pageNo > 1) {
              handlePrev();
              handleTabPage(curTab?.code, pageNo - 1);
            }
          }}
          handleNext={() => {
            handleNext();
            handleTabPage(curTab?.code, pageNo + 1);
          }}
        />
```

## 기타
@todo
useTab, TabHead 등을 대대적으로 수정하면서 기존 코드를 CardTab에 때려넣게 됨.
그리고 useCardTab을 따로 만들었다. 코드는 기존 코드와 거의 동일함.
추상화가 필요해보인다.
